### PR TITLE
Unicode handling fix

### DIFF
--- a/chompjs/test_parser.py
+++ b/chompjs/test_parser.py
@@ -84,9 +84,13 @@ class TestParser(unittest.TestCase):
         result = parse_js_object("[[[[[[[[[[[[[[[1]]]]]]]]]]]]]]]")
         self.assertEqual(result, [[[[[[[[[[[[[[[1]]]]]]]]]]]]]]])
 
-    def test_unicode(self):
+    def test_unicode_values(self):
         result = parse_js_object("['\u00E9']")
         self.assertEqual(result, ['é'])
+
+    def test_unicode_keys(self):
+        result = parse_js_object('{"cache":{"\u002Ftest\u002F": 0}}')
+        self.assertEqual(result, {'cache': {'/test/': 0}})
 
     def test_stack(self):
         result = parse_js_object(

--- a/chompjs/test_parser.py
+++ b/chompjs/test_parser.py
@@ -72,9 +72,9 @@ class TestParser(unittest.TestCase):
         result = parse_js_object("{'a': true, 'b': false, 'c': null}")
         self.assertEqual(result, {'a': True, 'b': False, 'c': None})
 
-    def test_quoted_strings(self):
-        result = parse_js_object("{'a': '123\\'456'}")
-        self.assertEqual(result, {'a': "123'456"})
+    def test_escaped_text(self):
+        result = parse_js_object("{'a': '123\\'456\\n'}")
+        self.assertEqual(result, {'a': "123\"456\n"})
 
     def test_multiple_identifiers(self):
         result = parse_js_object("{a:1,b:1,c:1,d:1,e:1,f:1,g:1,h:1,i:1,j:1}")

--- a/parser.c
+++ b/parser.c
@@ -141,30 +141,7 @@ struct State key(struct Lexer* lexer) {
     case '"':
     case '`':
         lexer->current_quotation = c;
-        emit('"', lexer);
 
-        while(1) {
-            c = lexer->input[lexer->input_position];
-            // handle escape sequences such as \\ and \'
-            if(c == '\\'){
-                char escaped = lexer->input[lexer->input_position+1];
-                if(escaped== '`' || escaped == '\'') {
-                    lexer->input_position += 1;
-                    emit(escaped, lexer);
-                } else {
-                    emit('\\', lexer);
-                    emit(escaped, lexer);
-                }
-            }
-            // if we're closing the quotations, we're done with the string
-            if(c == lexer->current_quotation) {
-                emit('"', lexer);
-                struct State new_state = {colon};
-                return new_state;
-            }
-            // otherwise, emit character
-            emit(c, lexer);
-        }
     case '}':
         if(last_char(lexer) == ',') {
             unemit(lexer);

--- a/parser.c
+++ b/parser.c
@@ -149,18 +149,17 @@ struct State key(struct Lexer* lexer) {
             if(c == '\\'){
                 emit('\\', lexer);
                 char escaped = lexer->input[lexer->input_position];
-                if(escaped== '`' || escaped == '\'') {
+                if(escaped == lexer->current_quotation) {
                     lexer->input_position += 1;
-                    emit(escaped, lexer);
+                    emit('"', lexer);
+                    lexer->input_position -= 1;
                 } else if(escaped=='u' || escaped=='U') {
                     emit(escaped, lexer);
-                    int i;
-                    for(i=0; i<4; ++i) {
-                        emit(lexer->input[lexer->input_position], lexer);
-                    }
+                    emit_string((char*)lexer->input+lexer->input_position, 4, lexer);
                 } else {
-                    emit('\\', lexer);
+                    lexer->input_position += 1;
                     emit(escaped, lexer);
+                    lexer->input_position -= 1;
                 }
                 continue;
             }
@@ -239,25 +238,23 @@ struct State value(struct Lexer* lexer) {
     case '`':
         lexer->current_quotation = c;
         emit('"', lexer);
-        
         while(1) {
             c = lexer->input[lexer->input_position];
             // handle escape sequences such as \\ and \'
             if(c == '\\'){
-                char escaped = lexer->input[lexer->input_position+1];
-                if(escaped== '`' || escaped == '\'') {
+                emit('\\', lexer);
+                char escaped = lexer->input[lexer->input_position];
+                if(escaped == lexer->current_quotation) {
                     lexer->input_position += 1;
-                    emit(escaped, lexer);
+                    emit('"', lexer);
+                    lexer->input_position -= 1;
                 } else if(escaped=='u' || escaped=='U') {
+                    emit(escaped, lexer);
+                    emit_string((char*)lexer->input+lexer->input_position, 4, lexer);
+                } else {
                     lexer->input_position += 1;
                     emit(escaped, lexer);
-                    int i;
-                    for(i=0; i<4; ++i) {
-                        emit(lexer->input[lexer->input_position], lexer);
-                    }
-                } else {
-                    emit('\\', lexer);
-                    emit(escaped, lexer);
+                    lexer->input_position -= 1;
                 }
                 continue;
             }

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 
 from io import open
 from os import path
+from platform import system
 from setuptools import setup, Extension
 
 
@@ -10,17 +11,22 @@ this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
+extra_compile_args = []
+extra_link_args = []
+if system() == 'Linux':
+    extra_compile_args = ['-Wl,-Bsymbolic-functions']
+    extra_link_args = ['-Wl,-Bsymbolic-functions']
 
 chompjs_extension = Extension(
     '_chompjs',
     sources=['module.c', 'parser.c'],
-    extra_compile_args=['-Wl,-Bsymbolic-functions'],
-    extra_link_args=['-Wl,-Bsymbolic-functions'],
+    extra_compile_args=extra_compile_args,
+    extra_link_args=extra_link_args,
 )
 
 setup(
     name='chompjs',
-    version='1.0.7',
+    version='1.0.8',
     description='Parsing JavaScript objects into Python dictionaries',
     author='Mariusz Obajtek',
     author_email='nykakin@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ chompjs_extension = Extension(
 
 setup(
     name='chompjs',
-    version='1.0.8',
+    version='1.0.9',
     description='Parsing JavaScript objects into Python dictionaries',
     author='Mariusz Obajtek',
     author_email='nykakin@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ chompjs_extension = Extension(
 
 setup(
     name='chompjs',
-    version='1.0.9',
+    version='1.0.10',
     description='Parsing JavaScript objects into Python dictionaries',
     author='Mariusz Obajtek',
     author_email='nykakin@gmail.com',


### PR DESCRIPTION
Parsing was failing if keys of JSON values contained Unicode. Minimal sample case:
```python
'{"cache":{"\u002Ftest\u002F": 0}}'
```