### PR TITLE
Handle windows whitespaces

### DIFF
--- a/chompjs/test_parser.py
+++ b/chompjs/test_parser.py
@@ -123,6 +123,10 @@ class TestParser(unittest.TestCase):
         result = parse_js_object('["Test\\nDrive"]\n{"Test": "Drive"}', jsonlines=True)
         self.assertEqual(result, [['Test\nDrive'], {'Test': 'Drive'}])
 
+    def test_windows_newlines(self):
+        result = parse_js_object('{"a":\r\n10}')
+        self.assertEqual(result, {'a': 10})                
+
 
 class TestParserExceptions(unittest.TestCase):
     def test_invalid_input(self):

--- a/parser.c
+++ b/parser.c
@@ -32,16 +32,11 @@ void advance(struct Lexer* lexer) {
 
 char next_char(struct Lexer* lexer) {
     while(1) {
-        switch(lexer->input[lexer->input_position]) {
-        case ' ':
-        case '\n':
-        case '\t':
+        if(isspace(lexer->input[lexer->input_position])) {
             lexer->input_position += 1;
             continue;
-        break;
-        default:
-            return lexer->input[lexer->input_position];
         }
+        return lexer->input[lexer->input_position];
     }
     return '\0';
 }

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ chompjs_extension = Extension(
 
 setup(
     name='chompjs',
-    version='1.0.11',
+    version='1.0.12',
     description='Parsing JavaScript objects into Python dictionaries',
     author='Mariusz Obajtek',
     author_email='nykakin@gmail.com',


### PR DESCRIPTION
Fixing throwing an exception if input string contains Windows-style whitespaces:
```python
>>> chompjs.parse_js_object('{\n}')
{}
>>> chompjs.parse_js_object('{\r\n}')
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/home/mariusz/Documents/Praca/venv/local/lib/python2.7/site-packages/chompjs/chompjs.py", line 27, in parse_js_object
    raise ValueError('Parser error: ... {}'.format(repr(str(exception))[1:-1]))
ValueError: Parser error: ... \r\n}
```