### PR TITLE
Handle escaped quotations correctly

### DIFF
--- a/chompjs/test_parser.py
+++ b/chompjs/test_parser.py
@@ -74,7 +74,7 @@ class TestParser(unittest.TestCase):
 
     def test_escaped_text(self):
         result = parse_js_object("{'a': '123\\'456\\n'}")
-        self.assertEqual(result, {'a': "123\"456\n"})
+        self.assertEqual(result, {'a': "123'456\n"})
 
     def test_multiple_identifiers(self):
         result = parse_js_object("{a:1,b:1,c:1,d:1,e:1,f:1,g:1,h:1,i:1,j:1}")
@@ -125,7 +125,11 @@ class TestParser(unittest.TestCase):
 
     def test_windows_newlines(self):
         result = parse_js_object('{"a":\r\n10}')
-        self.assertEqual(result, {'a': 10})                
+        self.assertEqual(result, {'a': 10})
+
+    def test_escaped_single_quotes(self):
+        result = parse_js_object('''{"a": "b\\'"}''')
+        self.assertEqual(result, {'a': "b'"})
 
 
 class TestParserExceptions(unittest.TestCase):

--- a/module.c
+++ b/module.c
@@ -6,7 +6,11 @@ static PyObject* parse_python_object(PyObject *self, PyObject *args) {
     const char* string;
     size_t initial_stack_size = 10;
     int is_jsonlines = 0;
+#if PY_MAJOR_VERSION >= 3
     if (!PyArg_ParseTuple(args, "s|np", &string, &initial_stack_size, &is_jsonlines)) {
+#else
+    if (!PyArg_ParseTuple(args, "s|ni", &string, &initial_stack_size, &is_jsonlines)) {
+#endif
         return NULL;
     }
 

--- a/parser.c
+++ b/parser.c
@@ -233,7 +233,13 @@ struct State value(struct Lexer* lexer) {
             c = lexer->input[lexer->input_position];
             // handle escape sequences such as \\ and \'
             if(c == '\\'){
-                emit('\\', lexer);
+                if(lexer->input[lexer->input_position+1] != '\'') {
+                    emit('\\', lexer);
+                } else {
+                    emit('\'', lexer);
+                    lexer->input_position += 1;
+                    continue;
+                }
                 char escaped = lexer->input[lexer->input_position];
                 if(escaped == lexer->current_quotation) {
                     lexer->input_position += 1;

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ chompjs_extension = Extension(
 
 setup(
     name='chompjs',
-    version='1.0.12',
+    version='1.0.13',
     description='Parsing JavaScript objects into Python dictionaries',
     author='Mariusz Obajtek',
     author_email='nykakin@gmail.com',


### PR DESCRIPTION
`json.loads` treats `\\'` as an invalid escape:

```python
>>> json.loads('''{"a": "\\'"}''')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.7/json/__init__.py", line 348, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.7/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.7/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
json.decoder.JSONDecodeError: Invalid \escape: line 1 column 8 (char 7)
```
So the library should translate `{"a": "\\'"}` to `{"a": "'"}`