### PR TITLE
Handle "undefined" keyword

### DIFF
--- a/chompjs/test_parser.py
+++ b/chompjs/test_parser.py
@@ -131,6 +131,13 @@ class TestParser(unittest.TestCase):
         result = parse_js_object('''{"a": "b\\'"}''')
         self.assertEqual(result, {'a': "b'"})
 
+    def test_unusual_values(self):
+        result = parse_js_object('{"a": undefined}')
+        self.assertEqual(result, {"a": "undefined"})
+
+        result = parse_js_object('[undefined, undefined]')
+        self.assertEqual(result, ["undefined", "undefined"])
+
 
 class TestParserExceptions(unittest.TestCase):
     def test_invalid_input(self):

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ chompjs_extension = Extension(
 
 setup(
     name='chompjs',
-    version='1.0.13',
+    version='1.0.14',
     description='Parsing JavaScript objects into Python dictionaries',
     author='Mariusz Obajtek',
     author_email='nykakin@gmail.com',


### PR DESCRIPTION
Error raised if `undefined` keyword is present in JavaScript object:

```python
>>> chompjs.parse_js_object('{"a": undefined}')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/mariusz/Documents/Praca/venv/local/lib/python2.7/site-packages/chompjs/chompjs.py", line 27, in parse_js_object
    raise ValueError('Parser error: ... {}'.format(repr(str(exception))[1:-1]))
ValueError: Parser error: ... undefined}
```

Resolved by quoting unrecognised values instead automatically reporting an error:

```python
>>> import chompjs
>>> chompjs.parse_js_object('{"a": undefined}')
{'a': 'undefined'}
```
