### PR TITLE
Add leading zero to some floats

### DIFF
--- a/chompjs/test_parser.py
+++ b/chompjs/test_parser.py
@@ -143,8 +143,8 @@ class TestParser(unittest.TestCase):
         self.assertEqual(result, {"_a": 1, "$b": 2})
 
     def test_floats_without_leading_zero(self):
-        result = parse_js_object('{"a": .99}')
-        self.assertEqual(result, {"a": 0.99})
+        result = parse_js_object('{"a": .99, "b": -.1}')
+        self.assertEqual(result, {"a": 0.99, "b": -.1})
 
 
 class TestParserExceptions(unittest.TestCase):

--- a/chompjs/test_parser.py
+++ b/chompjs/test_parser.py
@@ -142,6 +142,10 @@ class TestParser(unittest.TestCase):
         result = parse_js_object("{_a: 1, $b: 2}")
         self.assertEqual(result, {"_a": 1, "$b": 2})
 
+    def test_floats_without_leading_zero(self):
+        result = parse_js_object('{"a": .99}')
+        self.assertEqual(result, {"a": 0.99})
+
 
 class TestParserExceptions(unittest.TestCase):
     def test_invalid_input(self):

--- a/parser.c
+++ b/parser.c
@@ -287,6 +287,10 @@ struct State value(struct Lexer* lexer) {
         return new_dictionary_close_state;
     }
     if(isdigit(c) || c == '.' || c == '-') {
+        if(c == '.') {
+            emit_without_advancing('0', lexer);
+        }
+
         do {
             if(c != '_' && c != ' ') {
                 emit(c, lexer);

--- a/parser.c
+++ b/parser.c
@@ -287,6 +287,10 @@ struct State value(struct Lexer* lexer) {
         return new_dictionary_close_state;
     }
     if(isdigit(c) || c == '.' || c == '-') {
+        if(c == '-') {
+            emit('-', lexer);
+            c = tolower(lexer->input[lexer->input_position]);
+        }
         if(c == '.') {
             emit_without_advancing('0', lexer);
         }

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ chompjs_extension = Extension(
 
 setup(
     name='chompjs',
-    version='1.0.15',
+    version='1.0.16',
     description='Parsing JavaScript objects into Python dictionaries',
     author='Mariusz Obajtek',
     author_email='nykakin@gmail.com',


### PR DESCRIPTION
`json.loads` cannot handle floats in range (-1, 1) if they don't have leading zero:
```python
>>> import json
>>> json.loads('{"Test": 0.99}')
{u'Test': 0.99}
>>> json.loads('{"Test": .99}')
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/usr/lib/python2.7/json/__init__.py", line 339, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 364, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python2.7/json/decoder.py", line 382, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
```
Therefore the parser needs to add this `0` itself.