### PR TITLE
Handle memory corruption bugs on unclosed quotations

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,23 @@
+1.0.17
+* Handle memory corruption on unclosed quotations (#13)
+
+1.0.16
+* Handle floats with leading zeros (#10)
+
+1.0.15
+* Handle $ and _ characters at the beginning of keys (#9)
+
+1.0.14
+* Handle "undefined" keyword in JavaScript objects (#7)
+
+1.0.13
+* Handle escaped quotations correctly (#6)
+
+1.0.12
+* Handle windows newlines (#5)
+
+1.0.11
+* Handle jsonlines (#3)
+
+1.0.1
+* Handle Unicode in keys (#2)

--- a/parser.c
+++ b/parser.c
@@ -13,7 +13,8 @@ void init(struct Lexer* lexer, const char* string, size_t initial_stack_size, in
     // so output might be larger than input, especially for malicious input
     // such as '{a:1,b:1,c:1,d:1,e:1,f:1,g:1,h:1,i:1,j:1}' that is translated to
     // '{"a":1,"b":1,"c":1,"d":1,"e":1,"f":1,"g":1,"h":1,"i":1}'
-    lexer->output = malloc(2*strlen(string));
+    lexer->output_size = 2 * strlen(string);
+    lexer->output = malloc(lexer->output_size);
     lexer->input_position = 0;
     lexer->output_position = 0;
     struct State begin_state = {begin};
@@ -62,6 +63,15 @@ void emit(char c, struct Lexer* lexer) {
     lexer->output[lexer->output_position] = c;
     lexer->output_position += 1;
     lexer->input_position += 1;
+}
+
+int safe_emit(char c, struct Lexer* lexer) {
+    if(lexer->output_position > lexer->output_size) {
+        return 0;
+    } else {
+        emit(c, lexer);
+        return 1;
+    }
 }
 
 void emit_without_advancing(char c, struct Lexer* lexer) {
@@ -171,7 +181,10 @@ struct State key(struct Lexer* lexer) {
                 return new_state;
             }
             // otherwise, emit character
-            emit(c, lexer);
+            if(!safe_emit(c, lexer)) {
+                struct State error_state = {error};
+                return error_state;
+            }
         }
     case '}':
         if(last_char(lexer) == ',') {
@@ -267,7 +280,10 @@ struct State value(struct Lexer* lexer) {
                 return new_state;            
             }
             // otherwise, emit character
-            emit(c, lexer);
+            if(!safe_emit(c, lexer)) {
+                struct State error_state = {error};
+                return error_state;
+            }
         }
     case ']':
         if(last_char(lexer) == ',') {

--- a/parser.h
+++ b/parser.h
@@ -30,6 +30,7 @@ typedef enum {
 
 struct Lexer {
     const char* input;
+    size_t output_size;
     char* output;
     size_t input_position;
     size_t output_position;

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ chompjs_extension = Extension(
 
 setup(
     name='chompjs',
-    version='1.0.16',
+    version='1.0.17',
     description='Parsing JavaScript objects into Python dictionaries',
     author='Mariusz Obajtek',
     author_email='nykakin@gmail.com',


### PR DESCRIPTION
There are memory corruption errors caused by unbalanced quotations in source:

Sample code:
```python
import chompjs

json_data = None
try:
    json_data = chompjs.parse_js_object(u'{offer: {id: 4157573},name: "...')
except:
    pass

del json_data
```