### PR TITLE
Improve handling of newlines

### DIFF
--- a/chompjs/test_parser.py
+++ b/chompjs/test_parser.py
@@ -127,6 +127,9 @@ class TestParser(unittest.TestCase):
         result = parse_js_object('{"a":\r\n10}')
         self.assertEqual(result, {'a': 10})
 
+        result = parse_js_object("{'foo': 0,\r\n}")
+        self.assertEqual(result, {'foo': 0})
+
     def test_escaped_single_quotes(self):
         result = parse_js_object('''{"a": "b\\'"}''')
         self.assertEqual(result, {'a': "b'"})

--- a/parser.c
+++ b/parser.c
@@ -44,14 +44,10 @@ char next_char(struct Lexer* lexer) {
 char last_char(struct Lexer* lexer) {
     int index = lexer->input_position-1;
     while(index > 0) {
-        switch(lexer->input[index]) {
-        case ' ':
-        case '\n':
-        case '\t':
+        if(isspace(lexer->input[index])) {
             index -= 1;
             continue;
-        break;
-        default:
+        } else {
             return lexer->input[index];
         }
     }


### PR DESCRIPTION
Exception present if Windows newlines are present before closing `,` that needs to be removed:
```python
>>> chompjs.parse_js_object("{'foo': 0, \r\n}")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "chompjs/chompjs.py", line 34, in parse_js_object
    return json.loads(parsed_data)
  File "/usr/lib/python2.7/json/__init__.py", line 339, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 364, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python2.7/json/decoder.py", line 380, in raw_decode
    obj, end = self.scan_once(s, idx)
ValueError: Expecting property name: line 1 column 10 (char 9)

```