### PR TITLE
Handle comments in JavaScript

### DIFF
--- a/_chompjs/parser.c
+++ b/_chompjs/parser.c
@@ -147,6 +147,8 @@ struct State json(struct Lexer* lexer) {
         break;
         case ',':
             emit(',', lexer);
+        break;
+
         case '/':;
             char next_c = lexer->input[lexer->input_position+1];
             if(next_c == '/' || next_c == '*') {
@@ -349,7 +351,6 @@ struct State handle_unrecognized(struct Lexer* lexer) {
 void handle_comments(struct Lexer* lexer) {
     char c, next_c;
 
-
     lexer->input_position += 1;
     if(lexer->input[lexer->input_position] == '/' ) {
         for(;;) {
@@ -364,7 +365,6 @@ void handle_comments(struct Lexer* lexer) {
             lexer->input_position+=1;
             c = lexer->input[lexer->input_position];
             next_c = lexer->input[lexer->input_position+1];
-
             if((c == '\0') || (c == '*' && next_c == '/')) {
                 break;
             }

--- a/_chompjs/parser.c
+++ b/_chompjs/parser.c
@@ -30,16 +30,7 @@ char next_char(struct Lexer* lexer) {
 }
 
 char last_char(struct Lexer* lexer) {
-    int index = lexer->input_position-1;
-    while(index > 0) {
-        if(isspace(lexer->input[index])) {
-            index -= 1;
-            continue;
-        } else {
-            return lexer->input[index];
-        }
-    }
-    return '\0';
+    return top(&lexer->output);
 }
 
 void emit(char c, struct Lexer* lexer) {
@@ -156,6 +147,16 @@ struct State json(struct Lexer* lexer) {
         break;
         case ',':
             emit(',', lexer);
+        case '/':;
+            char next_c = lexer->input[lexer->input_position+1];
+            if(next_c == '/' || next_c == '*') {
+                handle_comments(lexer);
+            } else {
+                struct State value_state = {value};
+                return value_state;
+            }
+        break;
+
         default:;
             struct State value_state = {value};
             return value_state;
@@ -343,4 +344,31 @@ struct State handle_unrecognized(struct Lexer* lexer) {
 
     struct State error_state = {error};
     return error_state;   
+}
+
+void handle_comments(struct Lexer* lexer) {
+    char c, next_c;
+
+
+    lexer->input_position += 1;
+    if(lexer->input[lexer->input_position] == '/' ) {
+        for(;;) {
+            lexer->input_position+=1;
+            c = lexer->input[lexer->input_position];
+            if((c == '\0') || (c == '\n')) {
+                break;
+            }
+        }
+    } else if(lexer->input[lexer->input_position] == '*') {
+        for(;;) {
+            lexer->input_position+=1;
+            c = lexer->input[lexer->input_position];
+            next_c = lexer->input[lexer->input_position+1];
+
+            if((c == '\0') || (c == '*' && next_c == '/')) {
+                break;
+            }
+        }
+        lexer->input_position+=2;
+    }
 }

--- a/_chompjs/parser.h
+++ b/_chompjs/parser.h
@@ -98,6 +98,9 @@ void emit_string(char *s, size_t size, struct Lexer* lexer);
 /** Send string to output buffer, keep old input position */
 void emit_string_in_place(char *s, size_t size, struct Lexer* lexer);
 
+/** Handle comments in JSON body */
+void handle_comments(struct Lexer* lexer);
+
 /** Initialize main lexer object*/
 void init_lexer(struct Lexer* lexer, const char* string, bool is_jsonlines);
 

--- a/chompjs/test_parser.py
+++ b/chompjs/test_parser.py
@@ -116,6 +116,30 @@ class TestParser(unittest.TestCase):
         self.assertEqual(result, expected_data)
 
     @parametrize_test(
+        (
+            """
+                var obj = {
+                    // Comment
+                    x: "X", // Comment
+                };
+            """,
+            {"x": "X"},
+        ),
+        (
+            """
+                var /* Comment */ obj = /* Comment */ {
+                    /* Comment */
+                    x: /* Comment */ "X", /* Comment */
+                };
+            """,
+            {"x": "X"},
+        ),
+    )
+    def test_comments(self, in_data, expected_data):
+        result = parse_js_object(in_data)
+        self.assertEqual(result, expected_data)
+
+    @parametrize_test(
         ('["Test\\nDrive"]\n{"Test": "Drive"}', [['Test\nDrive'], {'Test': 'Drive'}]),
     )
     def test_jsonlines(self, in_data, expected_data):

--- a/chompjs/test_parser.py
+++ b/chompjs/test_parser.py
@@ -78,6 +78,7 @@ class TestParser(unittest.TestCase):
         ('{"a": 3.125e7}', {'a': 3.125e7}),
         ('''{"a": "b\\'"}''', {'a': "b'"}),
         ('{"a": .99, "b": -.1}', {"a": 0.99, "b": -.1}),
+        ('["/* ... */", "// ..."]', ["/* ... */", "// ..."]),
     )
     def test_parse_standard_values(self, in_data, expected_data):
         result = parse_js_object(in_data)
@@ -133,6 +134,10 @@ class TestParser(unittest.TestCase):
                 };
             """,
             {"x": "X"},
+        ),
+        (
+            """[/*...*/1,2,3,/*...*/4,5,6]""",
+            [1, 2, 3, 4, 5, 6],
         ),
     )
     def test_comments(self, in_data, expected_data):


### PR DESCRIPTION
Allows parsing JavaScript contaning comments inside:
```python
>>> import chompjs
>>> chompjs.parse_js_object('{A:/* ... */1024}')
{'A': 1024}
>>> chompjs.parse_js_object('{A:// ...\n1024}')
{'A': 1024}
```