### PR TITLE
Handle numeric keys

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 Dev
 * Performance improvement (#19)
+* Handle numeric keys (#20)
 
 1.1.3
 * Avoid an infinite loop on malformed input (#27)

--- a/_chompjs/buffer.c
+++ b/_chompjs/buffer.c
@@ -11,7 +11,7 @@
 
 void init_char_buffer(struct CharBuffer* buffer, size_t initial_depth_buffer_size) {
     buffer->data = malloc(initial_depth_buffer_size);
-    buffer->size = initial_depth_buffer_size;
+    buffer->memory_buffer_length = initial_depth_buffer_size;
     buffer->index = 0;
 }
 
@@ -22,16 +22,16 @@ void release_char_buffer(struct CharBuffer* buffer) {
 void push(struct CharBuffer* buffer, char value) {
     buffer->data[buffer->index] = value;
     buffer->index += 1;
-    if(buffer->index >= buffer->size) {
-        buffer->data = realloc(buffer->data, 2*buffer->size);
-        buffer->size *= 2;
+    if(buffer->index >= buffer->memory_buffer_length) {
+        buffer->data = realloc(buffer->data, 2*buffer->memory_buffer_length);
+        buffer->memory_buffer_length *= 2;
     }
 }
 
 void push_string(struct CharBuffer* buffer, char* value, size_t len) {
-    if(buffer->index + len >= buffer->size) {
-        buffer->data = realloc(buffer->data, 2*buffer->size);
-        buffer->size *= 2;
+    if(buffer->index + len >= buffer->memory_buffer_length) {
+        buffer->data = realloc(buffer->data, 2*buffer->memory_buffer_length);
+        buffer->memory_buffer_length *= 2;
     }
     memcpy(buffer->data + buffer->index, value, len);
     buffer->index += len;
@@ -51,4 +51,8 @@ bool empty(struct CharBuffer* buffer) {
 
 void clear(struct CharBuffer* buffer) {
     buffer->index = 0;
+}
+
+size_t size(struct CharBuffer* buffer) {
+    return buffer->index;
 }

--- a/_chompjs/buffer.h
+++ b/_chompjs/buffer.h
@@ -14,7 +14,7 @@
 */
 struct CharBuffer {
     char* data;
-    size_t size;
+    size_t memory_buffer_length;
     size_t index;
 };
 
@@ -33,5 +33,7 @@ char top(struct CharBuffer* buffer);
 bool empty(struct CharBuffer* buffer);
 
 void clear(struct CharBuffer* buffer);
+
+size_t size(struct CharBuffer* buffer);
 
 #endif

--- a/_chompjs/parser.c
+++ b/_chompjs/parser.c
@@ -91,6 +91,7 @@ struct State* begin(struct Lexer* lexer) {
     for(;;) {
         switch(next_char(lexer)) {
         case '{':
+            lexer->is_key = true;
         case '[':;
             return &states[JSON_STATE];
         break;
@@ -108,6 +109,7 @@ struct State* json(struct Lexer* lexer) {
         switch(next_char(lexer)) {
         case '{':
             push(&lexer->nesting_depth, '{');
+            lexer->is_key = true;
             emit('{', lexer);
         break;
         case '[':
@@ -119,6 +121,7 @@ struct State* json(struct Lexer* lexer) {
                 unemit(lexer);
             }
             pop(&lexer->nesting_depth);
+            lexer->is_key = top(&lexer->nesting_depth) == '{';
             emit('}', lexer);
             if(size(&lexer->nesting_depth) <= 0) {
                 if(lexer->is_jsonlines) {
@@ -134,6 +137,7 @@ struct State* json(struct Lexer* lexer) {
                 unemit(lexer);
             }
             pop(&lexer->nesting_depth);
+            lexer->is_key = top(&lexer->nesting_depth) == '{';
             emit(']', lexer);
             if(size(&lexer->nesting_depth) <= 0) {
                 if(lexer->is_jsonlines) {
@@ -145,10 +149,12 @@ struct State* json(struct Lexer* lexer) {
             }
         break;
         case ':':
+            lexer->is_key = false;
             emit(':', lexer);
         break;
         case ',':
             emit(',', lexer);
+            lexer->is_key = top(&lexer->nesting_depth) == '{';
 
         case '/':;
             char next_c = lexer->input[lexer->input_position+1];

--- a/_chompjs/parser.h
+++ b/_chompjs/parser.h
@@ -7,6 +7,7 @@
 #define CHOMPJS_PARSER_H
 
 #include <stddef.h>
+#include <stdbool.h>
 
 #include "buffer.h"
 
@@ -59,9 +60,10 @@ struct Lexer {
     size_t output_position;
     LexerStatus lexer_status;
     struct State* state;
-    size_t nesting_depth;
-    size_t helper_nesting_depth;
+    struct CharBuffer nesting_depth;
+    size_t unrecognized_nesting_depth;
     bool is_jsonlines;
+    bool is_key;
 };
 
 /** Switch state of internal state machine */

--- a/chompjs/test_parser.py
+++ b/chompjs/test_parser.py
@@ -101,6 +101,7 @@ class TestParser(unittest.TestCase):
         ("[0x12, 0xAB, 051, 0o51, 0b111]", ["0x12", "0xab", "051", "0o51", "0b111"]),
         ("{regex: /a[^d]{1,12}/i}", {'regex': '/a[^d]{1,12}/i'}),
         ("{'a': function(){return '\"'}}", {'a': 'function(){return \'"\'}'}),
+        ("{1: 1, 2: 2, 3: 3, 4: 4}", {'1': 1, '2': 2, '3': 3, '4': 4}),
     )
     def test_parse_strange_values(self, in_data, expected_data):
         result = parse_js_object(in_data)


### PR DESCRIPTION
Resolves (partially) #20.
```python
>>> chompjs.parse_js_object('{123: "aaa"}')
{'123': 'aaa'}
```
Unfortunately, current implementation doesn't allow simply parsing this as `{123: 'aaa'}` - numbers needs to be quoted. This might lead to unexpected behavior:
```python
>>> chompjs.parse_js_object('{123: "aaa", "123": "bbb"}')
{'123': 'bbb'}
```
The reason is this library uses `json.loads` to decode fixed input string - and it won't allow numeric keys. The best I can do is to quote them:
```python
>>> import json
>>> json.loads('{0: 12}')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.8/json/__init__.py", line 357, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.8/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.8/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)
>>> json.loads('{"0": 12}')
{'0': 12}
```