### PR TITLE
Refactor error handling

### DIFF
--- a/_chompjs/module.c
+++ b/_chompjs/module.c
@@ -28,10 +28,21 @@ static PyObject* parse_python_object(PyObject *self, PyObject *args) {
     PyObject* ret = Py_BuildValue("s#", lexer.output.data, lexer.output.index-1);
     release_lexer(&lexer);
     if(lexer.lexer_status == ERROR) {
-        char error_message[30];
-        memcpy(error_message, lexer.input+lexer.input_position, 30);
-
-        PyErr_SetString(PyExc_ValueError, error_message);
+        const char* msg_sting = "Error parsing input near character %d";
+        size_t error_buffer_size = snprintf(
+            NULL,
+            0,
+            msg_sting,
+            lexer.input_position
+        );       
+        char* error_buffer = malloc(error_buffer_size + 1);
+        sprintf(
+            error_buffer,
+            msg_sting,
+            lexer.input_position - 1
+        );
+        PyErr_SetString(PyExc_ValueError, error_buffer);
+        free(error_buffer);
         return NULL;
     }
     return ret;

--- a/chompjs/chompjs.py
+++ b/chompjs/chompjs.py
@@ -17,20 +17,8 @@ def parse_js_object(string, unicode_escape=False, jsonlines=False, json_params=N
     if not json_params:
         json_params = {}
 
-    # I use this roundabout way to capture exception because Python 2.7 doesn't
-    # support `raise ... from None` syntax and I don't want to include six.rethrow
-    # only to change exception message
-    exception = None
-    try:
-        parsed_data = parse(string, jsonlines)
-    except ValueError as e:
-        exception = e
-    if exception:
-        if sys.version_info[0] < 3:
-            raise ValueError('Parser error: ... {}'.format(repr(str(exception))[1:-1]))
-        else:
-            raise ValueError("Parser error: ... {}".format(str(exception).encode('utf-8')))
-
+    parsed_data = parse(string, jsonlines)
+        
     if jsonlines:
         return [json.loads(j, **json_params) for j in parsed_data.split('\0')]
     else:


### PR DESCRIPTION
Previously, error messages were providing part of problematic input, like this:
```python
>>> import chompjs
>>> chompjs.parse_js_object('{"asfbfdgfdgfd"> 1212121}')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/mariusz/Documents/Projekty/chompjs/chompjs/chompjs.py", line 20, in parse_js_object
    parsed_data = parse(string, jsonlines)
ValueError:  1212121}
```
This wasn't very helpful for many inputs. For example, in many cases all we've got is this message:
```python
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/mojo/dev/python/venv/lib/python3.9/site-packages/chompjs/chompjs.py", line 32, in parse_js_object
    raise ValueError("Parser error: ... {}".format(str(exception).encode('utf-8')))
ValueError: Parser error: ... b''
```
Refactored this so now exceptions will carry character position in the input where problems were spotted:
```python
>>> import chompjs
>>> chompjs.parse_js_object('{"asfbfdgfdgfd"> 1212121}')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/mariusz/Documents/Projekty/chompjs/chompjs/chompjs.py", line 20, in parse_js_object
    parsed_data = parse(string, jsonlines)
ValueError: Error parsing input near character 15
```

