### PR TITLE
Handle open quotations

### DIFF
--- a/_chompjs/parser.c
+++ b/_chompjs/parser.c
@@ -238,6 +238,9 @@ struct State* handle_quoted(struct Lexer* lexer) {
             }
             continue;
         }
+        if(c == '\0') {
+            return &states[ERROR_STATE];
+        }
         // if we're closing the quotations, we're done with the string
         if(c == current_quotation) {
             emit('"', lexer);

--- a/_chompjs/parser.c
+++ b/_chompjs/parser.c
@@ -238,6 +238,7 @@ struct State* handle_quoted(struct Lexer* lexer) {
             }
             continue;
         }
+        // in case of malformed quotation we can reach end of the input
         if(c == '\0') {
             return &states[ERROR_STATE];
         }

--- a/chompjs/test_parser.py
+++ b/chompjs/test_parser.py
@@ -7,12 +7,12 @@ import unittest
 from chompjs import parse_js_object
 
 
-def parametrize_test(*arguments):
+def parametrize_test(*arguments_list):
     def decorate(func):
         @functools.wraps(func)
         def wrapper(self, *args, **kwargs):
-            for (in_data, expected_data) in arguments:
-                func(self, in_data, expected_data)
+            for arguments in arguments_list:
+                func(self, *arguments)
         return wrapper
     return decorate
 
@@ -168,6 +168,17 @@ class TestParserExceptions(unittest.TestCase):
     )
     def test_malformed_input(self, in_data, expected_exception):
         with self.assertRaises(expected_exception):
+            parse_js_object(in_data)
+
+    @parametrize_test(
+        (
+            '{"test": """}',
+            ValueError,
+            'Error parsing input near character 13',
+        ),
+    )
+    def test_error_messages(self, in_data, expected_exception, expected_exception_text):
+        with self.assertRaisesRegex(expected_exception, expected_exception_text):
             parse_js_object(in_data)
 
 


### PR DESCRIPTION
Consider following malformed input: `'{"test": """}'`. There's an extra open quote character at the end. Trying to parse it reveals a problem: 
```python
>>> chompjs.parse_js_object('{"test": """}')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/mariusz/Documents/Projekty/chompjs/venv/lib/python3.9/site-packages/chompjs-1.1.4-py3.9-linux-x86_64.egg/chompjs/chompjs.py", line 20, in parse_js_object
    parsed_data = parse(string, jsonlines)
ValueError: Error parsing input near character 1462
>>> chompjs.parse_js_object('{"test": """}')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/mariusz/Documents/Projekty/chompjs/venv/lib/python3.9/site-packages/chompjs-1.1.4-py3.9-linux-x86_64.egg/chompjs/chompjs.py", line 20, in parse_js_object
    parsed_data = parse(string, jsonlines)
ValueError: Error parsing input near character 2237
>>> chompjs.parse_js_object('{"test": """}')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/mariusz/Documents/Projekty/chompjs/venv/lib/python3.9/site-packages/chompjs-1.1.4-py3.9-linux-x86_64.egg/chompjs/chompjs.py", line 20, in parse_js_object
    parsed_data = parse(string, jsonlines)
ValueError: Error parsing input near character 1462
```
As it can be seen, incorrect input is reported on positions far beyond input text (1462, 2237, 1462), meaning that parser is iterating on memory outside of the input, until it encounter a byte causing it to stop. In some cases such a byte is not a valid UTF-8, resulting with a different type of exception:
```python
>>> chompjs.parse_js_object('{"test": """}')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/mariusz/Documents/Projekty/chompjs/venv/lib/python3.9/site-packages/chompjs-1.1.4-py3.9-linux-x86_64.egg/chompjs/chompjs.py", line 20, in parse_js_object
    parsed_data = parse(string, jsonlines)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa0 in position 23: invalid start byte
```
To bypass this, an extra check during parsing string literals is added. If the input text is detected to be a null byte, meaning we've reached end of the input string, then it is treated as an error, forcing parser to return before entering invalid memory.


