### PR TITLE
Handle parser failing on certain arrays

### DIFF
--- a/_chompjs/parser.c
+++ b/_chompjs/parser.c
@@ -155,6 +155,7 @@ struct State* json(struct Lexer* lexer) {
         case ',':
             emit(',', lexer);
             lexer->is_key = top(&lexer->nesting_depth) == '{';
+        break;
 
         case '/':;
             char next_c = lexer->input[lexer->input_position+1];

--- a/chompjs/test_parser.py
+++ b/chompjs/test_parser.py
@@ -79,6 +79,7 @@ class TestParser(unittest.TestCase):
         ('''{"a": "b\\'"}''', {'a': "b'"}),
         ('{"a": .99, "b": -.1}', {"a": 0.99, "b": -.1}),
         ('["/* ... */", "// ..."]', ["/* ... */", "// ..."]),
+        ('{"inclusions":["/*","/"]}', {'inclusions': ['/*', '/']}),
     )
     def test_parse_standard_values(self, in_data, expected_data):
         result = parse_js_object(in_data)


### PR DESCRIPTION
Sample input parsing failing: `["","/"]` (works with space between array elements, `["", "/"]`).