### PR TITLE
Allow trailing dot at the end of numerals

### DIFF
--- a/_chompjs/parser.c
+++ b/_chompjs/parser.c
@@ -305,6 +305,10 @@ struct State* handle_numeric(struct Lexer* lexer) {
     // [97, 102] is ASCII range for a-f, for hex digits
     } while(isdigit(c) || c == '.' || c == '_' || (c >= 97 && c <= 102));
 
+    if(lexer->input[lexer->input_position-1] == '.') {
+        emit_in_place('0', lexer);
+    }
+
     if(to_be_quoted) {
         emit_in_place('"', lexer);
     }

--- a/chompjs/test_parser.py
+++ b/chompjs/test_parser.py
@@ -109,6 +109,7 @@ class TestParser(unittest.TestCase):
         ("{regex: /a[^d]{1,12}/i}", {'regex': '/a[^d]{1,12}/i'}),
         ("{'a': function(){return '\"'}}", {'a': 'function(){return \'"\'}'}),
         ("{1: 1, 2: 2, 3: 3, 4: 4}", {'1': 1, '2': 2, '3': 3, '4': 4}),
+        ("{'a': 121.}", {'a': 121.0})
     )
     def test_parse_strange_values(self, in_data, expected_data):
         result = parse_js_object(in_data)


### PR DESCRIPTION
This fix allow handling numerals with trailing dot. Before:
```python
>>> import chompjs
>>> chompjs.parse_js_object('{"a": 12.}')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/mariusz/Documents/Praca/venv/lib/python3.9/site-packages/chompjs-1.1.8-py3.9-linux-x86_64.egg/chompjs/chompjs.py", line 25, in parse_js_object
    return json.loads(parsed_data, **json_params)
  File "/usr/lib/python3.9/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.9/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.9/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
json.decoder.JSONDecodeError: Expecting ',' delimiter: line 1 column 8 (char 7)
```
Now:
```python
>>> import chompjs
>>> chompjs.parse_js_object('{"a": 12.}')
{'a': 12.0}
```