### PR TITLE
Drop Python 2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,31 +117,31 @@ As a result, `json.loads` fail to extract any of those:
 >>> json.loads("{'a': 'b'}")
 Traceback (most recent call last):
   File "<console>", line 1, in <module>
-  File "/usr/lib/python2.7/json/__init__.py", line 339, in loads
+  File "/usr/lib/python3.10/json/__init__.py", line 339, in loads
     return _default_decoder.decode(s)
-  File "/usr/lib/python2.7/json/decoder.py", line 364, in decode
+  File "/usr/lib/python3.10/json/decoder.py", line 364, in decode
     obj, end = self.raw_decode(s, idx=_w(s, 0).end())
-  File "/usr/lib/python2.7/json/decoder.py", line 380, in raw_decode
+  File "/usr/lib/python3.10/json/decoder.py", line 380, in raw_decode
     obj, end = self.scan_once(s, idx)
 ValueError: Expecting property name: line 1 column 2 (char 1)
 >>> json.loads('{a: "b"}')
 Traceback (most recent call last):
   File "<console>", line 1, in <module>
-  File "/usr/lib/python2.7/json/__init__.py", line 339, in loads
+  File "/usr/lib/python3.10/json/__init__.py", line 339, in loads
     return _default_decoder.decode(s)
-  File "/usr/lib/python2.7/json/decoder.py", line 364, in decode
+  File "/usr/lib/python3.10/json/decoder.py", line 364, in decode
     obj, end = self.raw_decode(s, idx=_w(s, 0).end())
-  File "/usr/lib/python2.7/json/decoder.py", line 380, in raw_decode
+  File "/usr/lib/python3.10/json/decoder.py", line 380, in raw_decode
     obj, end = self.scan_once(s, idx)
 ValueError: Expecting property name: line 1 column 2 (char 1)
 >>> json.loads('{"a": [1, 2, 3,]}')
 Traceback (most recent call last):
   File "<console>", line 1, in <module>
-  File "/usr/lib/python2.7/json/__init__.py", line 339, in loads
+  File "/usr/lib/python3.10/json/__init__.py", line 339, in loads
     return _default_decoder.decode(s)
-  File "/usr/lib/python2.7/json/decoder.py", line 364, in decode
+  File "/usr/lib/python3.10/json/decoder.py", line 364, in decode
     obj, end = self.raw_decode(s, idx=_w(s, 0).end())
-  File "/usr/lib/python2.7/json/decoder.py", line 382, in raw_decode
+  File "/usr/lib/python3.10/json/decoder.py", line 382, in raw_decode
     raise ValueError("No JSON object could be decoded")
 ValueError: No JSON object could be decoded
 >>> json.loads('{"a": .99}')

--- a/_chompjs/module.c
+++ b/_chompjs/module.c
@@ -11,11 +11,7 @@
 static PyObject* parse_python_object(PyObject *self, PyObject *args) {
     const char* string;
     int is_jsonlines = 0;
-#if PY_MAJOR_VERSION >= 3
     if (!PyArg_ParseTuple(args, "s|p", &string, &is_jsonlines)) {
-#else
-    if (!PyArg_ParseTuple(args, "s|i", &string, &is_jsonlines)) {
-#endif
         return NULL;
     }
 
@@ -57,8 +53,6 @@ static PyMethodDef parser_methods[] = {
 };
 
 
-#if PY_MAJOR_VERSION >= 3
-
 static struct PyModuleDef parser_definition = { 
     PyModuleDef_HEAD_INIT,
     "_chompjs",
@@ -71,11 +65,3 @@ PyMODINIT_FUNC PyInit__chompjs(void) {
     Py_Initialize();
     return PyModule_Create(&parser_definition);
 }
-
-#else
-
-PyObject* init_chompjs(void) {
-    return Py_InitModule("_chompjs", parser_methods);
-}
-
-#endif

--- a/setup.py
+++ b/setup.py
@@ -31,10 +31,10 @@ setup(
     author='Mariusz Obajtek',
     author_email='nykakin@gmail.com',
     keywords='parsing parser JavaScript json',
+    python_requires='>=3',
     ext_modules=[chompjs_extension],
     classifiers=[
         "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 3",
         "Programming Language :: JavaScript",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py2, py3
+envlist = py3
 
 [testenv]
 commands =


### PR DESCRIPTION
Python 2.7 is no longer supported. Removing the support for it to make future development easier.