### PR TITLE
Drop jsonlines flag

### DIFF
--- a/_chompjs/module.c
+++ b/_chompjs/module.c
@@ -10,13 +10,12 @@
 
 static PyObject* parse_python_object(PyObject *self, PyObject *args) {
     const char* string;
-    int is_jsonlines = 0;
-    if (!PyArg_ParseTuple(args, "s|p", &string, &is_jsonlines)) {
+    if (!PyArg_ParseTuple(args, "s", &string)) {
         return NULL;
     }
 
     struct Lexer lexer;
-    init_lexer(&lexer, string, is_jsonlines);
+    init_lexer(&lexer, string);
     while(lexer.lexer_status == CAN_ADVANCE) {
         advance(&lexer);
     }
@@ -59,7 +58,7 @@ static PyObject* json_iter_new(PyTypeObject *type, PyObject *args, PyObject *kwa
     if (!PyArg_ParseTuple(args, "s", &string)) {
         return NULL;
     }
-    init_lexer(&json_iter_state->lexer, string, false);
+    init_lexer(&json_iter_state->lexer, string);
 
     return (PyObject* )json_iter_state;
 }

--- a/_chompjs/parser.c
+++ b/_chompjs/parser.c
@@ -70,7 +70,7 @@ void emit_number_in_place(long value, struct Lexer* lexer) {
     push_number(&lexer->output, value);
 }
 
-void init_lexer(struct Lexer* lexer, const char* string, bool is_jsonlines) {
+void init_lexer(struct Lexer* lexer, const char* string) {
     lexer->input = string;
     // allocate in advance more memory for output than for input because we might need
     // to add extra characters
@@ -82,7 +82,6 @@ void init_lexer(struct Lexer* lexer, const char* string, bool is_jsonlines) {
     lexer->unrecognized_nesting_depth = 0;
     lexer->lexer_status = CAN_ADVANCE;
     lexer->state = &states[BEGIN_STATE];
-    lexer->is_jsonlines = is_jsonlines;
     lexer->is_key = false;
 }
 
@@ -136,12 +135,7 @@ struct State* json(struct Lexer* lexer) {
             lexer->is_key = top(&lexer->nesting_depth) == '{';
             emit('}', lexer);
             if(size(&lexer->nesting_depth) <= 0) {
-                if(lexer->is_jsonlines) {
-                    emit_in_place('\0', lexer);
-                    return &states[BEGIN_STATE];
-                } else {
-                    return &states[END_STATE];
-                }
+                return &states[END_STATE];
             }
         break;
         case ']':
@@ -152,12 +146,7 @@ struct State* json(struct Lexer* lexer) {
             lexer->is_key = top(&lexer->nesting_depth) == '{';
             emit(']', lexer);
             if(size(&lexer->nesting_depth) <= 0) {
-                if(lexer->is_jsonlines) {
-                    emit_in_place('\0', lexer);
-                    return &states[BEGIN_STATE];
-                } else {
-                    return &states[END_STATE];
-                }
+                return &states[END_STATE];
             }
         break;
         case ':':
@@ -232,9 +221,7 @@ struct State* value(struct Lexer* lexer) {
 }
 
 struct State* end(struct Lexer* lexer) {
-    if(!lexer->is_jsonlines) {
-        emit('\0', lexer);
-    }
+    emit('\0', lexer);
     lexer->lexer_status = FINISHED;
     return lexer->state;
 }

--- a/_chompjs/parser.h
+++ b/_chompjs/parser.h
@@ -64,7 +64,6 @@ struct Lexer {
     struct State* state;
     struct CharBuffer nesting_depth;
     size_t unrecognized_nesting_depth;
-    bool is_jsonlines;
     bool is_key;
 };
 
@@ -99,7 +98,7 @@ void emit_number_in_place(long value, struct Lexer* lexer);
 void handle_comments(struct Lexer* lexer);
 
 /** Initialize main lexer object */
-void init_lexer(struct Lexer* lexer, const char* string, bool is_jsonlines);
+void init_lexer(struct Lexer* lexer, const char* string);
 
 /** Reset main lexer object output buffer */
 void reset_lexer_output(struct Lexer* lexer);

--- a/chompjs/chompjs.py
+++ b/chompjs/chompjs.py
@@ -11,7 +11,7 @@ def _preprocess(string, unicode_escape=False):
     return string
 
 
-def parse_js_object(string, unicode_escape=False, jsonlines=False, json_params=None):
+def parse_js_object(string, unicode_escape=False, json_params=None):
     if not string:
         raise ValueError('Invalid input')
 
@@ -19,12 +19,8 @@ def parse_js_object(string, unicode_escape=False, jsonlines=False, json_params=N
     if not json_params:
         json_params = {}
 
-    parsed_data = parse(string, jsonlines)
-
-    if jsonlines:
-        return [json.loads(j, **json_params) for j in parsed_data.split('\0')]
-    else:
-        return json.loads(parsed_data, **json_params)
+    parsed_data = parse(string)
+    return json.loads(parsed_data, **json_params)
 
 
 def parse_js_objects(string, unicode_escape=False, omitempty=False, json_params=None):

--- a/chompjs/test_parser.py
+++ b/chompjs/test_parser.py
@@ -213,7 +213,7 @@ class TestParser(unittest.TestCase):
         ('["Test\\nDrive"]\n{"Test": "Drive"}', [['Test\nDrive'], {'Test': 'Drive'}]),
     )
     def test_jsonlines(self, in_data, expected_data):
-        result = parse_js_object(in_data, jsonlines=True)
+        result = list(parse_js_objects(in_data))
         self.assertEqual(result, expected_data)
 
 


### PR DESCRIPTION
Now that https://github.com/Nykakin/chompjs/pull/45 is implemented we no longer need `jsonlines` flag in `parse_js_object` because we can just get the data using `parse_js_objects`. 
```python
>>> data = """
... {'a': 12}
... {'b': 12}
... {'c': 12}
... """
>>> import chompjs
>>> list(chompjs.parse_js_objects(data))
[{'a': 12}, {'b': 12}, {'c': 12}]
```