### PR TITLE
Fix compilation on windows

### DIFF
--- a/_chompjs/module.c
+++ b/_chompjs/module.c
@@ -85,7 +85,7 @@ static PyObject* json_iter_next(JsonIterState* json_iter_state) {
 }
 
 PyTypeObject JSONIter_Type = {
-    PyVarObject_HEAD_INIT(&PyType_Type, 0)
+    PyVarObject_HEAD_INIT(NULL, 0)
     "json_iter",                    /* tp_name */
     sizeof(JsonIterState),          /* tp_basicsize */
     0,                              /* tp_itemsize */

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ chompjs_extension = Extension(
 
 setup(
     name='chompjs',
-    version='1.2.0',
+    version='1.2.1',
     description='Parsing JavaScript objects into Python dictionaries',
     author='Mariusz Obajtek',
     author_email='nykakin@gmail.com',


### PR DESCRIPTION
Resolving https://github.com/Nykakin/chompjs/issues/48

When I've looked to some tutorial as to how to write an generator in C API I've found a blogpost that used following way to initialize Python type object head:
```C
PyVarObject_HEAD_INIT(&PyType_Type, 0)
```
According to [this](https://stackoverflow.com/questions/45401933/initializer-is-not-a-constant-error-c2099-on-compiling-a-module-written-in-c-f) this should be:
```C
PyVarObject_HEAD_INIT(NULL, 0)
```
Indeed, in the newer examples in [docs](https://docs.python.org/3.10/extending/newtypes.html) `NULL` is always used. The warning that `what we’d like to write is PyVarObject_HEAD_INIT(&PyType_Type, 0)` was dropped in documentation since 3.6.