### PR TITLE
Fix number-of-digits calculation

### DIFF
--- a/_chompjs/buffer.c
+++ b/_chompjs/buffer.c
@@ -40,7 +40,12 @@ void push_string(struct CharBuffer* buffer, const char* value, size_t len) {
 }
 
 void push_number(struct CharBuffer* buffer, long value) {
-    int size_in_chars = (int)((ceil(log10(value))));
+    int size_in_chars;
+    if (value == 0) {
+        size_in_chars = 2;
+    } else {
+        size_in_chars = floor(log10(value)) + 2;
+    }
     check_capacity(buffer, size_in_chars);
     buffer->index += sprintf(buffer->data + buffer->index, "%ld", value);
 }


### PR DESCRIPTION
This fixes some bugs in the buffer size calculation for push_number.

For value 0, size_in_chars would be set to -2147483648. This caused a resize of the buffer and in some cases resulted in a segfault. The following test code triggers a segfault for me on Linux and Mac.

```
import chompjs

jsdata = """
var x = [0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
         0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
         0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
         0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0];
"""

chompjs.parse_js_object(jsdata)
```

This commit also fixes an off-by-one where the value is a round number (10, 100, 1000) and adds one extra character to allow for sprintf's terminating null.