### PR TITLE
Remove trailing whitespaces from unquoted keys

### DIFF
--- a/_chompjs/parser.c
+++ b/_chompjs/parser.c
@@ -389,6 +389,10 @@ struct State* handle_unrecognized(struct Lexer* lexer) {
             case ',':
             case ':':
                 if(!currently_quoted_with && lexer->unrecognized_nesting_depth <= 0) {
+                    // remove trailing whitespaces
+                    while(isspace(last_char(lexer))) {
+                        pop(&lexer->output);
+                    }
                     emit_in_place('"', lexer);
                     return &states[JSON_STATE];
                 } else {

--- a/_chompjs/parser.h
+++ b/_chompjs/parser.h
@@ -61,7 +61,6 @@ struct Lexer {
     size_t output_size;
     struct CharBuffer output;
     size_t input_position;
-    size_t output_position;
     LexerStatus lexer_status;
     struct State* state;
     struct CharBuffer nesting_depth;

--- a/chompjs/test_parser.py
+++ b/chompjs/test_parser.py
@@ -107,7 +107,9 @@ class TestParser(unittest.TestCase):
         ("{regex: /a[^d]{1,12}/i}", {'regex': '/a[^d]{1,12}/i'}),
         ("{'a': function(){return '\"'}}", {'a': 'function(){return \'"\'}'}),
         ("{1: 1, 2: 2, 3: 3, 4: 4}", {'1': 1, '2': 2, '3': 3, '4': 4}),
-        ("{'a': 121.}", {'a': 121.0})
+        ("{'a': 121.}", {'a': 121.0}),
+        ("{abc : 100}", {'abc': 100}),
+        ("{abc     :       100}", {'abc': 100}),
     )
     def test_parse_strange_values(self, in_data, expected_data):
         result = parse_js_object(in_data)


### PR DESCRIPTION
If an unquoted key has trailing spaces, they are not removed:
```python
>>> import chompjs
>>> 
>>> chompjs.parse_js_object("{a   :   12}")
{'a   ': 12}
```
Expected output:
```python
{'a': 12}
```