### PR TITLE
Remove trailing whitespaces for unrecognized values

### DIFF
--- a/_chompjs/parser.c
+++ b/_chompjs/parser.c
@@ -381,6 +381,10 @@ struct State* handle_unrecognized(struct Lexer* lexer) {
                     emit(c, lexer);
                     lexer->unrecognized_nesting_depth -= 1;
                 } else {
+                    // remove trailing whitespaces after value
+                    while(isspace(last_char(lexer))) {
+                        pop(&lexer->output);
+                    }
                     emit_in_place('"', lexer);
                     return &states[JSON_STATE];
                 }
@@ -389,7 +393,7 @@ struct State* handle_unrecognized(struct Lexer* lexer) {
             case ',':
             case ':':
                 if(!currently_quoted_with && lexer->unrecognized_nesting_depth <= 0) {
-                    // remove trailing whitespaces
+                    // remove trailing whitespaces before ':'
                     while(isspace(last_char(lexer))) {
                         pop(&lexer->output);
                     }

--- a/_chompjs/parser.c
+++ b/_chompjs/parser.c
@@ -393,7 +393,7 @@ struct State* handle_unrecognized(struct Lexer* lexer) {
             case ',':
             case ':':
                 if(!currently_quoted_with && lexer->unrecognized_nesting_depth <= 0) {
-                    // remove trailing whitespaces before ':'
+                    // remove trailing whitespaces after key
                     while(isspace(last_char(lexer))) {
                         pop(&lexer->output);
                     }

--- a/chompjs/test_parser.py
+++ b/chompjs/test_parser.py
@@ -110,6 +110,12 @@ class TestParser(unittest.TestCase):
         ("{'a': 121.}", {'a': 121.0}),
         ("{abc : 100}", {'abc': 100}),
         ("{abc     :       100}", {'abc': 100}),
+        ("{abc: name }", {'abc': "name"}),
+        ("{abc: name\t}", {'abc': "name"}),
+        ("{abc: value\n}", {'abc': "value"}),
+        ("{abc:  name}", {'abc': "name"}),
+        ("{abc: \tname}", {'abc': "name"}),
+        ("{abc: \nvalue}", {'abc': "value"}),
     )
     def test_parse_strange_values(self, in_data, expected_data):
         result = parse_js_object(in_data)


### PR DESCRIPTION
Fixes #58

Follow up to https://github.com/Nykakin/chompjs/pull/57 Not only keys can have trailing whitespaces to be removed, unquoted values can have them too.
```python
>>> chompjs.parse_js_object("{'a':b   }")
{'a': 'b   '}
```
Expected output:
```python
{'a': 'b'}
```
Even worse, if trailing whitespaces contain tabs and newlines, parsing raises an Exception:
```python
>>> chompjs.parse_js_object("{'a':b\n}")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/mariusz/Documents/Praca/majornetlocs-venv/lib/python3.11/site-packages/chompjs/chompjs.py", line 74, in parse_js_object
    return json.loads(parsed_data, **json_params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
               ^^^^^^^^^^^^^^^^^^^^^^
json.decoder.JSONDecodeError: Invalid control character at: line 1 column 8 (char 7)
```