### PR TITLE
Release the GIL during parsing in C

### DIFF
--- a/_chompjs/module.c
+++ b/_chompjs/module.c
@@ -16,9 +16,11 @@ static PyObject* parse_python_object(PyObject *self, PyObject *args) {
 
     struct Lexer lexer;
     init_lexer(&lexer, string);
+    Py_BEGIN_ALLOW_THREADS 
     while(lexer.lexer_status == CAN_ADVANCE) {
         advance(&lexer);
     }
+    Py_END_ALLOW_THREADS
 
     PyObject* ret = Py_BuildValue("s#", lexer.output.data, lexer.output.index-1);
     release_lexer(&lexer);
@@ -69,9 +71,12 @@ static void json_iter_dealloc(JsonIterState* json_iter_state) {
 }
 
 static PyObject* json_iter_next(JsonIterState* json_iter_state) {
+    Py_BEGIN_ALLOW_THREADS
     while(json_iter_state->lexer.lexer_status == CAN_ADVANCE) {
         advance(&json_iter_state->lexer);
     }
+    Py_END_ALLOW_THREADS
+
     if(json_iter_state->lexer.output.index == 1) {
         return NULL;
     }


### PR DESCRIPTION
## Rationale

When parsing large JavaScript objects using `chompjs`, I often want my scraper to continue making requests, without blocking on CPU-bound parsing tasks. This is easily done by offloading the parsing to a separate process:
```python
from concurrent.futures import ProcessPoolExecutor
result = await asyncio.run_in_executor(ProcessPoolExecutor(), parse_js_object, js_input)
```
However, using processes comes with overhead and isn't always practical—especially in environments with limited resources. In these cases, using `ThreadPoolExecutor` is preferable.

To make `ThreadPoolExecutor` a viable option, this PR modifies the C extension to release the GIL during parts of the parsing logic that do not interact with Python objects. This enables parse_js_object to be executed concurrently in threads.

This PR

-  Adds Py_BEGIN_ALLOW_THREADS / Py_END_ALLOW_THREADS around safe, compute-intensive parsing sections in the C extension.
- Ensures thread safety by limiting GIL release to regions that do not manipulate Python objects directly.

## Performance

Using the following test setup:
```python
import asyncio
import unittest

class TestGILRelease(unittest.TestCase):
    def test_parse_js_object_multithreaded(self):
        with open("twitter.json", encoding='utf-8') as f:
            js_input = f.read()

        async def test():
            loop = asyncio.get_event_loop()
            await asyncio.gather(*[
                loop.run_in_executor(None, lambda: parse_js_object(js_input))
                for _ in range(100)
            ])

        asyncio.run(test())
```
Switching from GIL-held to GIL-released parsing results in a ~30% speedup when using threads.

> Note: A ProcessPoolExecutor still achieves higher performance (~40-60% speedup), but incurs additional memory and process overhead. This PR focuses on enabling thread-based concurrency, which is lighter and sufficient in many real-world scenarios.

All existing unit tests pass without errors.