### PR TITLE
Handle arrow functions

### DIFF
--- a/_chompjs/parser.c
+++ b/_chompjs/parser.c
@@ -374,7 +374,7 @@ struct State* handle_unrecognized(struct Lexer* lexer) {
             case '}':
             case ']':
             case '>':
-                if(lexer->input[lexer->input_position-1]=='=') {
+                if(lexer->input[lexer->input_position-1] == '=') {
                     emit(c, lexer);
                     continue;
                 }

--- a/_chompjs/parser.c
+++ b/_chompjs/parser.c
@@ -374,6 +374,10 @@ struct State* handle_unrecognized(struct Lexer* lexer) {
             case '}':
             case ']':
             case '>':
+                if(lexer->input[lexer->input_position-1]=='=') {
+                    emit(c, lexer);
+                    continue;
+                }
             case ')':
                 if(currently_quoted_with && lexer->unrecognized_nesting_depth > 0) {
                     emit(c, lexer);

--- a/chompjs/test_parser.py
+++ b/chompjs/test_parser.py
@@ -116,6 +116,7 @@ class TestParser(unittest.TestCase):
         ("{abc:  name}", {'abc': "name"}),
         ("{abc: \tname}", {'abc': "name"}),
         ("{abc: \nvalue}", {'abc': "value"}),
+        ("{someProp: someArg => someFunc(someArg)}", {"someProp": "someArg => someFunc(someArg)"}),
     )
     def test_parse_strange_values(self, in_data, expected_data):
         result = parse_js_object(in_data)


### PR DESCRIPTION
Should resolve #71 for most simple cases

```python
>>> chompjs.parse_js_object("{someProp: someArg => someFunc(someArg)}")
{'someProp': 'someArg => someFunc(someArg)'}
```

Note that the library is not a fully functional JS parser so I can imagine malformed input to not work as expected.