### PR TITLE
Add test-compile workflow

### DIFF
--- a/.github/workflows/test-compile.yml
+++ b/.github/workflows/test-compile.yml
@@ -1,0 +1,39 @@
+name: test-compile
+
+on:
+  workflow_dispatch:
+  
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.22.0
+        env:
+           CIBW_SKIP: cp36-* cp37-* cp38-* pp*
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: chompjs-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: chompjs-sdist
+          path: dist/*.tar.gz


### PR DESCRIPTION
Looks like after merging a recent change (either #72 or #65) the code doesn't compile anymore with MacOS, detected during a test deploy (https://github.com/Nykakin/chompjs/actions/runs/16007757964/job/45158243819)

For a convenience and to avoid such issues in the future, this PR adds a new workflow that can be used to test compilation on different platforms and compilers.