### PR TITLE
Add type annotations

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 graft _chompjs
+include chompjs/py.typed

--- a/chompjs/__init__.py
+++ b/chompjs/__init__.py
@@ -1,1 +1,3 @@
 from .chompjs import parse_js_object, parse_js_objects
+
+__all__ = ["parse_js_object", "parse_js_objects"]

--- a/chompjs/chompjs.py
+++ b/chompjs/chompjs.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import json
 import warnings
-from typing import Any, Protocol, TypeVar, TYPE_CHECKING
+from typing import Any, Protocol, TypeVar, TYPE_CHECKING, Generic
 from _chompjs import parse, parse_objects # type: ignore[reportAttributeAccessIssue,attr-defined]
 
 
@@ -12,10 +12,11 @@ if TYPE_CHECKING:
 
     _T = TypeVar("_T")
     _T2 = TypeVar("_T2")
+    _T_co = TypeVar("_T_co", covariant=True)
 
-    class _JsonLoader(Protocol):
+    class _JsonLoader(Generic[_T_co], Protocol):
 
-        def __call__(self, obj: str, / , *args: Any, **kwargs: Any) -> Any: ...
+        def __call__(self, obj: str, / , *args: Any, **kwargs: Any) -> _T_co: ...
 
 
 def _preprocess(string: str, unicode_escape: bool=False) -> str:
@@ -46,11 +47,11 @@ def _process_loader_arguments(
 def parse_js_object(
     string: str,
     unicode_escape: bool=False,
-    loader: _JsonLoader=json.loads,
+    loader: _JsonLoader[_T_co]=json.loads,
     loader_args: Sequence[Any] | None=None,
     loader_kwargs: Mapping[str, Any] | None=None,
     json_params: Mapping[str, Any] | None=None,
-) -> Any:
+) -> _T_co:
     """
     Extracts first JSON object encountered in the input string
 
@@ -134,11 +135,11 @@ def parse_js_objects(
     string: str,
     unicode_escape: bool=False,
     omitempty: bool=False, 
-    loader: _JsonLoader=json.loads,
+    loader: _JsonLoader[_T_co]=json.loads,
     loader_args: Sequence[Any] | None=None,
     loader_kwargs: Mapping[str, Any] | None=None,
     json_params: Mapping[str, Any] | None=None,
-)-> Iterable[Any]:
+)-> Iterable[_T_co]:
     """
     Returns a generator extracting all JSON objects encountered in the input string.
     Can be used to read JSON Lines

--- a/chompjs/chompjs.py
+++ b/chompjs/chompjs.py
@@ -1,20 +1,22 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
 import json
 import warnings
-from typing import Any, Protocol, TypeVar
+from typing import Any, Protocol, TypeVar, TYPE_CHECKING
 
-from _chompjs import parse, parse_objects # type: ignore[reportAttributeAccessIssue]
-
-
-_T = TypeVar("_T")
-_T2 = TypeVar("_T2")
+from _chompjs import parse, parse_objects # type: ignore[reportAttributeAccessIssue,attr-defined]
 
 
-class _JsonLoader(Protocol):
+if TYPE_CHECKING:
+    _T = TypeVar("_T")
+    _T2 = TypeVar("_T2")
 
-    def __call__(self, obj: str, / , *args: Any, **kwargs: Any) -> Any: ...
+
+    class _JsonLoader(Protocol):
+
+        def __call__(self, obj: str, / , *args: Any, **kwargs: Any) -> Any: ...
 
 
 def _preprocess(string: str, unicode_escape: bool=False) -> str:

--- a/chompjs/chompjs.py
+++ b/chompjs/chompjs.py
@@ -1,18 +1,33 @@
 # -*- coding: utf-8 -*-
 
+from collections.abc import Iterable, Mapping, Sequence
 import json
 import warnings
+from typing import Any, Protocol, TypeVar
 
-from _chompjs import parse, parse_objects
+from _chompjs import parse, parse_objects # type: ignore[reportAttributeAccessIssue]
 
 
-def _preprocess(string, unicode_escape=False):
+_T = TypeVar("_T")
+_T2 = TypeVar("_T2")
+
+
+class _JsonLoader(Protocol):
+
+    def __call__(self, obj: str, / , *args: Any, **kwargs: Any) -> Any: ...
+
+
+def _preprocess(string: str, unicode_escape: bool=False) -> str:
     if unicode_escape:
         string = string.encode().decode("unicode_escape")
     return string
 
 
-def _process_loader_arguments(loader_args, loader_kwargs, json_params):
+def _process_loader_arguments(
+    loader_args: Sequence[_T] | None, 
+    loader_kwargs: Mapping[str, _T2] | None, 
+    json_params: Mapping[str, _T2] | None,
+) -> tuple[Sequence[_T], Mapping[str, _T2]]:
     if json_params:
         msg = "json_params argument is deprecated, please use loader_kwargs instead"
         warnings.warn(msg, DeprecationWarning)
@@ -28,13 +43,13 @@ def _process_loader_arguments(loader_args, loader_kwargs, json_params):
 
 
 def parse_js_object(
-    string,
-    unicode_escape=False,
-    loader=json.loads,
-    loader_args=None,
-    loader_kwargs=None,
-    json_params=None,
-):
+    string: str,
+    unicode_escape: bool=False,
+    loader: _JsonLoader=json.loads,
+    loader_args: Sequence[Any] | None=None,
+    loader_kwargs: Mapping[str, Any] | None=None,
+    json_params: Mapping[str, Any] | None=None,
+) -> Any:
     """
     Extracts first JSON object encountered in the input string
 
@@ -115,14 +130,14 @@ def parse_js_object(
 
 
 def parse_js_objects(
-    string,
-    unicode_escape=False,
-    omitempty=False, 
-    loader=json.loads,
-    loader_args=None,
-    loader_kwargs=None,
-    json_params=None,
-):
+    string: str,
+    unicode_escape: bool=False,
+    omitempty: bool=False, 
+    loader: _JsonLoader=json.loads,
+    loader_args: Sequence[Any] | None=None,
+    loader_kwargs: Mapping[str, Any] | None=None,
+    json_params: Mapping[str, Any] | None=None,
+)-> Iterable[Any]:
     """
     Returns a generator extracting all JSON objects encountered in the input string.
     Can be used to read JSON Lines

--- a/chompjs/chompjs.py
+++ b/chompjs/chompjs.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import json
 import warnings
-from typing import Any, Protocol, TypeVar, TYPE_CHECKING, Generic
+from typing import Any, Protocol, TypeVar, TYPE_CHECKING
 from _chompjs import parse, parse_objects # type: ignore[reportAttributeAccessIssue,attr-defined]
 
 
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     _T2 = TypeVar("_T2")
     _T_co = TypeVar("_T_co", covariant=True)
 
-    class _JsonLoader(Generic[_T_co], Protocol):
+    class _JsonLoader(Protocol[_T_co]):
 
         def __call__(self, obj: str, / , *args: Any, **kwargs: Any) -> _T_co: ...
 

--- a/chompjs/chompjs.py
+++ b/chompjs/chompjs.py
@@ -1,18 +1,17 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping, Sequence
 import json
 import warnings
 from typing import Any, Protocol, TypeVar, TYPE_CHECKING
-
 from _chompjs import parse, parse_objects # type: ignore[reportAttributeAccessIssue,attr-defined]
 
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping, Sequence
+
     _T = TypeVar("_T")
     _T2 = TypeVar("_T2")
-
 
     class _JsonLoader(Protocol):
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,10 @@
 envlist = py39,py310,py311,py312,py313
 
 [testenv]
-deps = orjson
+deps = 
+    orjson
+    mypy
 commands =
     python -m unittest discover
     python -m doctest chompjs/chompjs.py
+    mypy chompjs/chompjs.py


### PR DESCRIPTION
- Adds type annotations to all python functions
- Add `py.typed` to package data so annotations can be detected by type checkers

The docs strings already had annotations but this makes detection automatic by type checkers.

There are 2 differences with annotations from the docs:

- `loader_args` is annotated to accept a generic `Sequence` instead of a `list` since it will actually work with any sequence.
- `loader_kwargs` and `json_params` are annotated to accept a generic `Mapping` for the same reason.

Type hints use python 3.8 compatible syntax since that's the minimum required version listed in `setup.py`