### PR TITLE
Fix compilation error on MacOS

### DIFF
--- a/_chompjs/parser.c
+++ b/_chompjs/parser.c
@@ -109,10 +109,12 @@ struct State* begin(struct Lexer* lexer) {
         case '\0':;
             return &states[END_STATE];
         case '/':
-            char next_c = lexer->input[lexer->input_position+1];
-            if(next_c == '/' || next_c == '*') {
-                handle_comments(lexer);
-            }
+            {
+                char next_c = lexer->input[lexer->input_position+1];
+                if(next_c == '/' || next_c == '*') {
+                    handle_comments(lexer);
+                }
+            }                
         default:
             lexer->input_position += 1;
         }


### PR DESCRIPTION
Code wasn't compiling on MacOS (see action https://github.com/Nykakin/chompjs/actions/runs/16007992871)

Reason for errors explained in detail [here](https://stackoverflow.com/questions/92396/why-cant-variables-be-declared-in-a-switch-statement/92439#92439)

Now testing workflow managed to compile code as expected: https://github.com/Nykakin/chompjs/actions/runs/16711800982