### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     author='Mariusz Obajtek',
     author_email='nykakin@gmail.com',
     keywords='parsing parser JavaScript json json5 webscrapping',
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     ext_modules=[chompjs_extension],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Ass Python 3.8 reached end of its life according to https://devguide.python.org/versions/, I guess it's safe to remove support for it starting from version 1.4.0.