### PR TITLE
Fix deployment issues

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/upload-artifact@v6
         with:
-          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          name: chompjs-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
 
   build_sdist:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: chompjs-*
           path: dist

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: chompjs-*
           path: dist

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -19,6 +19,7 @@ jobs:
           pattern: chompjs-*
           path: dist
           merge-multiple: true
+          skip-existing: true
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -19,8 +19,8 @@ jobs:
           pattern: chompjs-*
           path: dist
           merge-multiple: true
-          skip-existing: true
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          skip-existing: true

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 [1.4.1]
 * Support building wheels for Python 3.14 (#78)
+* Fix deployment issues (#79)
 
 [1.4.0]
 * Handle arrow functions (#72)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 [1.4.1]
-* Support Python 3.14 (#78)
+* Support building wheels for Python 3.14 (#78)
 
 [1.4.0]
 * Handle arrow functions (#72)


### PR DESCRIPTION
After updating workflows in https://github.com/Nykakin/chompjs/pull/78 it looks like deployment only picks `sdist` build and not wheels: https://github.com/Nykakin/chompjs/actions/runs/25974264811/job/76352145182

> Found 4 artifact(s)
> Filtering artifacts by pattern 'chompjs-*'
> Preparing to download the following artifacts:
> \- chompjs-sdist (ID: 7037117422, Size: 17442, Expected Digest: sha256:29e19b9bd27e649218539aaf98c01837cf630dc994a3358aee91ec74a2939975)
Redirecting to blob download url: https://productionresultssa7.blob.core.windows.net/actions-results/7a0e57a5-3c89-4587-9dcc-751584970aa2/workflow-job-run-bed0c7eb-3898-59ab-9f0e-cac3bbf1790a/artifacts/1e309ca04eaa803ba4ca291a9ce4085e34c45f8eccf5d06b0bc3526d442db89a.zip
Starting download of artifact to: /home/runner/work/chompjs/chompjs/dist
(node:2141) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
SHA256 digest of downloaded artifact is 29e19b9bd27e649218539aaf98c01837cf630dc994a3358aee91ec74a2939975
Artifact download completed successfully.
Total of 1 artifact(s) downloaded
Download artifact has finished successfull